### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/docs/_ext/flask_app.py
+++ b/docs/_ext/flask_app.py
@@ -23,8 +23,8 @@
 def setup(sphinx):
     """Setup Sphinx object."""
     from flask import has_app_context
-    from invenio.base.factory import create_app
-    PACKAGES = ['invenio.base', 'invenio.modules.accounts',
+    from invenio_base.factory import create_app
+    PACKAGES = ['invenio_base', 'invenio.modules.accounts',
                 'invenio.modules.records', 'invenio_knowledge']
 
     if not has_app_context():

--- a/invenio_knowledge/admin.py
+++ b/invenio_knowledge/admin.py
@@ -23,7 +23,7 @@ import os
 
 from flask import request
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.ext.admin.views import ModelView
 from invenio.ext.sqlalchemy import db
 

--- a/invenio_knowledge/api.py
+++ b/invenio_knowledge/api.py
@@ -23,8 +23,8 @@ import json
 import os
 import warnings
 
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 from invenio_collections.models import Collection

--- a/invenio_knowledge/forms.py
+++ b/invenio_knowledge/forms.py
@@ -19,7 +19,7 @@
 
 """Knowledge Forms."""
 
-from invenio.base.i18n import _
+from invenio_base.i18n import _
 from invenio.utils.forms import InvenioBaseForm
 
 from werkzeug.local import LocalProxy

--- a/invenio_knowledge/manage.py
+++ b/invenio_knowledge/manage.py
@@ -85,7 +85,7 @@ def load(name, filepath, separator="---"):
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_knowledge/models.py
+++ b/invenio_knowledge/models.py
@@ -21,7 +21,7 @@
 
 import os
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
 from invenio_collections.models import Collection

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,9 +21,7 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-#
-# TODO: Add development versions of some important dependencies here to get a
-#       warning when there are breaking upstream changes, e.g.:
-#
-#     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
-#     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
+-e git+git://github.com/inveniosoftware/invenio-collections.git#egg=invenio-collections
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.2.1',
     'invenio-collections>=0.1.0',
     'invenio-upgrader>=0.1.0',
 ]
@@ -51,6 +52,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/tests/test_knowledge_restful.py
+++ b/tests/test_knowledge_restful.py
@@ -21,7 +21,7 @@
 
 from __future__ import print_function
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.ext.restful.utils import APITestCase
 from invenio.ext.sqlalchemy.utils import session_manager
 from invenio.testsuite import make_test_suite, run_test_suite


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>