### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel"
+  - "travis_retry pip install check-manifest mock twine wheel"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -62,6 +62,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_knowledge --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_knowledge --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -25,5 +25,6 @@
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-collections.git#egg=invenio-collections
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
 -e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ test_requirements = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'coverage>=4.0.0',
+    'invenio-testing>=0.1.1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ requirements = [
 test_requirements = [
     'unittest2>=1.1.0',
     'Flask_Testing>=0.4.1',
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -81,9 +81,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2009, 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -19,7 +19,7 @@
 
 """Unit tests for BibKnowledge."""
 
-from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 
 class BibknowledgeTests(InvenioTestCase):
@@ -33,10 +33,3 @@ class BibknowledgeTests(InvenioTestCase):
     def tearDown(self):
         """bbibknowledge unit test cleanup"""
         pass
-
-
-TEST_SUITE = make_test_suite(BibknowledgeTests)
-
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)

--- a/tests/test_knowledge_restful.py
+++ b/tests/test_knowledge_restful.py
@@ -22,11 +22,11 @@
 from __future__ import print_function
 
 from invenio_base.wrappers import lazy_import
+
 from invenio_ext.restful.utils import APITestCase
 from invenio_ext.sqlalchemy.utils import session_manager
-from invenio.testsuite import make_test_suite, run_test_suite
 
-db = lazy_import('invenio.ext.sqlalchemy.db')
+db = lazy_import('invenio_ext.sqlalchemy.db')
 
 
 class TestKnowledgeRestfulAPI(APITestCase):
@@ -292,8 +292,3 @@ class TestKnowledgeRestfulAPI(APITestCase):
                 user_id=1,
                 code=405,
             )
-
-TEST_SUITE = make_test_suite(TestKnowledgeRestfulAPI)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>