### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,10 +24,10 @@ Authors
 =======
 
 Invenio Knowledge is a module developed for the `Invenio
-<http://invenio-software.org>`_ digital library software.
+<http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org
-<mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org
+<mailto:info@inveniosoftware.org>`_.
 
 - Benoit Thiell <bthiell@cfa.harvard.edu>
 - Christopher Dickinson <christopher.dickinson@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -39,8 +39,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Knowledge.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-knowledge
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-knowledge',
     packages=[
         'invenio_knowledge',


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>